### PR TITLE
Correct the behavior of the tsconfig option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ function ensureInstance(webpack: IWebPack, options: ICompilerOptions, instanceNa
         lib6: loadLib(lib6Path)
     };
 
-    let configFileName = tsImpl.findConfigFile(options.tsconfig || process.cwd());
+    let configFileName = options.tsconfig || 'tsconfig.json';
     let configFile = null;
 
     let tsConfigFiles = [];


### PR DESCRIPTION
Due to: Microsoft/TypeScript#2965 the findConfigFile method will always return 'tsconfig.json'.
Therefore, the tsconfig query was not working.
